### PR TITLE
:zap: Add Data properties and params to handler input

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -74,13 +74,16 @@ workerComet.route({
 
 workerComet.route({
   pathname: '/test/:id',
+  params: z.strictObject({
+    id: z.string()
+  }),
   method: GET,
   before: [ logger('local before'), auth, perm ],
   after: [ logger('local after') ]
-}, async ({ event }) => {
-  const { id } = event.params
+}, async ({ event, params }) => {
+  const { id } = params
   // console.log(event)
-  console.log(event.userId)
+  console.log(event.userId, id)
   // await new Promise(resolve => setTimeout(resolve, 2000))
   return event.reply.ok({ found: true })
 })
@@ -88,7 +91,7 @@ workerComet.route({
 workerComet.route({
   pathname: '/test',
   method: POST
-}, async ({ event, env, logger }) => {
+}, async ({ event, env, logger, request, body }) => {
   //
   // env.MY_KV // exist
   // console.log(event.ctx.waitUntil) // exists
@@ -120,10 +123,11 @@ workerComet.route({
     [Status.Ok]: z.strictObject({ foo: z.string() }),
     [Status.InternalServerError]: z.strictObject({ message: z.string() })
   }
-}, async ({ event }) => {
+}, async ({ event, body }) => {
   try {
     //
     console.log(event.body)
+    body.foo
     //
     event.body
     event.params

--- a/src/router.ts
+++ b/src/router.ts
@@ -36,7 +36,7 @@ export interface Route {
   compatibilityDate?: string
   before?: MiddlewareList
   after?: MiddlewareList
-  handler: (input: { event: any; env: Environment; logger: Logger }) => MaybePromise<Reply>
+  handler: (input: { event: any; env: Environment; logger: Logger; reply: any; body: any; params: any; query: any } & Data ) => MaybePromise<Reply>
   replies?: Partial<Record<Status, ZodType>>
   schemas: {
     body?: ZodType
@@ -87,12 +87,13 @@ export class Router<
       params?: Params
       query?: Query
     },
-    handler: (input: {
+    handler: (input: Data & {
       event: Data & RouteContext<IsDo> & RouteParams<Body, Params, Query> & { reply: ReplyFrom<Replies> }
         & ExtensionsFrom<SBefore> & ExtensionsFrom<RBefore>
       env: Environment
       logger: Logger
-    }) => MaybePromise<Reply>
+      reply: ReplyFrom<Replies>
+    } & RouteParams<Body, Params, Query>) => MaybePromise<Reply>
   ): void => {
     const pathname = `${this.options.prefix ?? ''}${options.pathname ?? '*'}`
     const method = (options.method ?? Method.ALL) as Method

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,7 +68,7 @@ export class Server<
           ...(isDurableObject ? { state: ctxOrState } : { ctx: ctxOrState })
         }
 
-        const input = { event, env, logger }
+        const input = { event, env, logger, reply, ...data }
 
         span.setAttribute('isDurableObject', isDurableObject)
 


### PR DESCRIPTION
This PR adds `request`, `url` and other event properties and params (body, params, query) directly to the handler, saving on more `event.` prefixes.